### PR TITLE
CE-425 ParserUtil::sanitizeUrl() in Location::setUrl() adds unnecessa…

### DIFF
--- a/Entity/LinkedInUser.php
+++ b/Entity/LinkedInUser.php
@@ -11,6 +11,7 @@
 namespace CampaignChain\Location\LinkedInBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use CampaignChain\CoreBundle\Util\ParserUtil;
 
 /**
  * @ORM\Entity
@@ -200,7 +201,7 @@ class LinkedInUser
      */
     public function setProfileUrl($profileUrl)
     {
-        $this->profileUrl = $profileUrl;
+        $this->profileUrl = ParserUtil::sanitizeUrl($profileUrl);
 
         return $this;
     }


### PR DESCRIPTION
…ry trailing slash that causes e.g. GoToWebinar links to not work
